### PR TITLE
Improve performance of bulk translate mutations

### DIFF
--- a/saleor/graphql/translations/mutations/product_translate.py
+++ b/saleor/graphql/translations/mutations/product_translate.py
@@ -48,8 +48,8 @@ class ProductTranslate(BaseTranslateMutationWithSlug):
             )
             product = ChannelContext(node=instance, channel_slug=None)
             if created:
-                cls.call_event(manager.translation_created, translation)
+                cls.call_event(manager.translations_created, [translation])
             else:
-                cls.call_event(manager.translation_updated, translation)
+                cls.call_event(manager.translations_updated, [translation])
 
         return cls(**{cls._meta.return_field_name: product})

--- a/saleor/graphql/translations/mutations/product_variant_translate.py
+++ b/saleor/graphql/translations/mutations/product_variant_translate.py
@@ -51,8 +51,8 @@ class ProductVariantTranslate(BaseTranslateMutation):
         cls.call_event(manager.product_variant_updated, context.node)
 
         if created:
-            cls.call_event(manager.translation_created, translation)
+            cls.call_event(manager.translations_created, [translation])
         else:
-            cls.call_event(manager.translation_updated, translation)
+            cls.call_event(manager.translations_updated, [translation])
 
         return cls(**{cls._meta.return_field_name: context})

--- a/saleor/graphql/translations/mutations/promotion_rule_translate.py
+++ b/saleor/graphql/translations/mutations/promotion_rule_translate.py
@@ -54,8 +54,8 @@ class PromotionRuleTranslate(BaseTranslateMutation):
 
         manager = get_plugin_manager_promise(info.context).get()
         if created:
-            cls.call_event(manager.translation_created, translation)
+            cls.call_event(manager.translations_created, [translation])
         else:
-            cls.call_event(manager.translation_updated, translation)
+            cls.call_event(manager.translations_updated, [translation])
 
         return cls(**{cls._meta.return_field_name: instance})

--- a/saleor/graphql/translations/mutations/promotion_translate.py
+++ b/saleor/graphql/translations/mutations/promotion_translate.py
@@ -54,8 +54,8 @@ class PromotionTranslate(BaseTranslateMutation):
 
         manager = get_plugin_manager_promise(info.context).get()
         if created:
-            cls.call_event(manager.translation_created, translation)
+            cls.call_event(manager.translations_created, [translation])
         else:
-            cls.call_event(manager.translation_updated, translation)
+            cls.call_event(manager.translations_updated, [translation])
 
         return cls(**{cls._meta.return_field_name: instance})

--- a/saleor/graphql/translations/mutations/sale_translate.py
+++ b/saleor/graphql/translations/mutations/sale_translate.py
@@ -55,9 +55,9 @@ class SaleTranslate(BaseTranslateMutation):
         manager = get_plugin_manager_promise(info.context).get()
 
         if created:
-            cls.call_event(manager.translation_created, translation)
+            cls.call_event(manager.translations_created, [translation])
         else:
-            cls.call_event(manager.translation_updated, translation)
+            cls.call_event(manager.translations_updated, [translation])
 
         return cls(
             **{

--- a/saleor/graphql/translations/mutations/shop_settings_translate.py
+++ b/saleor/graphql/translations/mutations/shop_settings_translate.py
@@ -52,8 +52,8 @@ class ShopSettingsTranslate(BaseMutation):
             )
 
         if created:
-            cls.call_event(manager.translation_created, translation)
+            cls.call_event(manager.translations_created, [translation])
         else:
-            cls.call_event(manager.translation_updated, translation)
+            cls.call_event(manager.translations_updated, [translation])
 
         return ShopSettingsTranslate(shop=Shop())

--- a/saleor/graphql/translations/mutations/utils.py
+++ b/saleor/graphql/translations/mutations/utils.py
@@ -155,9 +155,9 @@ class BaseTranslateMutation(ModelMutation):
         manager = get_plugin_manager_promise(info.context).get()
 
         if created:
-            cls.call_event(manager.translation_created, translation)
+            cls.call_event(manager.translations_created, [translation])
         else:
-            cls.call_event(manager.translation_updated, translation)
+            cls.call_event(manager.translations_updated, [translation])
 
         return cls(**{cls._meta.return_field_name: instance})
 
@@ -479,21 +479,19 @@ class BaseBulkTranslateMutation(BaseMutation):
 
         if created_translations:
             webhooks = get_webhooks_for_event(WebhookEventAsyncType.TRANSLATION_CREATED)
-            for translation in created_translations:
-                cls.call_event(
-                    manager.translation_created,
-                    translation,
-                    webhooks=webhooks,
-                )
+            cls.call_event(
+                manager.translations_created,
+                created_translations,
+                webhooks=webhooks,
+            )
 
         if updated_translations:
             webhooks = get_webhooks_for_event(WebhookEventAsyncType.TRANSLATION_UPDATED)
-            for translation in updated_translations:
-                cls.call_event(
-                    manager.translation_updated,
-                    translation,
-                    webhooks=webhooks,
-                )
+            cls.call_event(
+                manager.translations_updated,
+                updated_translations,
+                webhooks=webhooks,
+            )
 
     @classmethod
     @traced_atomic_transaction()

--- a/saleor/graphql/translations/tests/mutations/test_attribute_bulk_translate.py
+++ b/saleor/graphql/translations/tests/mutations/test_attribute_bulk_translate.py
@@ -30,7 +30,7 @@ ATTRIBUTE_BULK_TRANSLATE_MUTATION = """
 """
 
 
-@patch("saleor.plugins.manager.PluginsManager.translation_created")
+@patch("saleor.plugins.manager.PluginsManager.translations_created")
 def test_attribute_bulk_translate_creates_translations(
     created_webhook_mock,
     staff_api_client,
@@ -76,10 +76,10 @@ def test_attribute_bulk_translate_creates_translations(
     assert data["count"] == 2
     assert data["results"][0]["translation"]["name"] == "Czerwony"
     assert data["results"][1]["translation"]["name"] == "Rot"
-    assert created_webhook_mock.call_count == 2
+    assert created_webhook_mock.call_count == 1
 
 
-@patch("saleor.plugins.manager.PluginsManager.translation_updated")
+@patch("saleor.plugins.manager.PluginsManager.translations_updated")
 def test_attribute_bulk_translate_updates_translations(
     updated_webhook_mock,
     staff_api_client,
@@ -127,10 +127,10 @@ def test_attribute_bulk_translate_updates_translations(
     assert data["count"] == 2
     assert data["results"][0]["translation"]["name"] == "NewCzerwony"
     assert data["results"][1]["translation"]["name"] == "NewRot"
-    assert updated_webhook_mock.call_count == 2
+    assert updated_webhook_mock.call_count == 1
 
 
-@patch("saleor.plugins.manager.PluginsManager.translation_created")
+@patch("saleor.plugins.manager.PluginsManager.translations_created")
 def test_attribute_bulk_translate_creates_translations_using_attr_external_ref(
     created_webhook_mock,
     staff_api_client,
@@ -176,10 +176,10 @@ def test_attribute_bulk_translate_creates_translations_using_attr_external_ref(
     assert data["count"] == 2
     assert data["results"][0]["translation"]["name"] == "Czerwony"
     assert data["results"][1]["translation"]["name"] == "Rot"
-    assert created_webhook_mock.call_count == 2
+    assert created_webhook_mock.call_count == 1
 
 
-@patch("saleor.plugins.manager.PluginsManager.translation_updated")
+@patch("saleor.plugins.manager.PluginsManager.translations_updated")
 def test_attribute_bulk_translate_updates_translations_using_attr_external_ref(
     updated_webhook_mock,
     staff_api_client,
@@ -226,7 +226,7 @@ def test_attribute_bulk_translate_updates_translations_using_attr_external_ref(
     assert data["count"] == 2
     assert data["results"][0]["translation"]["name"] == "NewCzerwony"
     assert data["results"][1]["translation"]["name"] == "NewRot"
-    assert updated_webhook_mock.call_count == 2
+    assert updated_webhook_mock.call_count == 1
 
 
 def test_attribute_bulk_translate_return_error_when_attr_id_and_external_ref(

--- a/saleor/graphql/translations/tests/mutations/test_attribute_value_bulk_transalte.py
+++ b/saleor/graphql/translations/tests/mutations/test_attribute_value_bulk_transalte.py
@@ -34,7 +34,7 @@ ATTRIBUTE_VALUE_BULK_TRANSLATE_MUTATION = """
 """
 
 
-@patch("saleor.plugins.manager.PluginsManager.translation_created")
+@patch("saleor.plugins.manager.PluginsManager.translations_created")
 def test_attribute_value_bulk_translate_creates_translations(
     created_webhook_mock,
     staff_api_client,
@@ -91,10 +91,10 @@ def test_attribute_value_bulk_translate_creates_translations(
     assert data["results"][1]["translation"]["name"] == "Rot"
     assert data["results"][1]["translation"]["plainText"] == expected_text
     assert data["results"][1]["translation"]["richText"] == expected_rich_text
-    assert created_webhook_mock.call_count == 2
+    assert created_webhook_mock.call_count == 1
 
 
-@patch("saleor.plugins.manager.PluginsManager.translation_created")
+@patch("saleor.plugins.manager.PluginsManager.translations_created")
 def test_attribute_value_bulk_translate_creates_name_from_translations_long_text(
     created_webhook_mock,
     staff_api_client,
@@ -137,7 +137,7 @@ def test_attribute_value_bulk_translate_creates_name_from_translations_long_text
     assert created_webhook_mock.call_count == 1
 
 
-@patch("saleor.plugins.manager.PluginsManager.translation_updated")
+@patch("saleor.plugins.manager.PluginsManager.translations_updated")
 def test_attribute_value_bulk_translate_updates_translations(
     updated_webhook_mock,
     staff_api_client,
@@ -193,10 +193,10 @@ def test_attribute_value_bulk_translate_updates_translations(
     assert data["results"][1]["translation"]["name"] == "Rot"
     assert data["results"][1]["translation"]["plainText"] == expected_text
     assert data["results"][1]["translation"]["richText"] == expected_rich_text
-    assert updated_webhook_mock.call_count == 2
+    assert updated_webhook_mock.call_count == 1
 
 
-@patch("saleor.plugins.manager.PluginsManager.translation_created")
+@patch("saleor.plugins.manager.PluginsManager.translations_created")
 def test_attribute_value_bulk_translate_creates_translations_using_value_external_ref(
     created_webhook_mock,
     staff_api_client,
@@ -254,10 +254,10 @@ def test_attribute_value_bulk_translate_creates_translations_using_value_externa
     assert data["results"][1]["translation"]["name"] == "Rot"
     assert data["results"][1]["translation"]["plainText"] == expected_text
     assert data["results"][1]["translation"]["richText"] == expected_rich_text
-    assert created_webhook_mock.call_count == 2
+    assert created_webhook_mock.call_count == 1
 
 
-@patch("saleor.plugins.manager.PluginsManager.translation_updated")
+@patch("saleor.plugins.manager.PluginsManager.translations_updated")
 def test_attribute_value_bulk_translate_updates_translations_using_value_external_ref(
     updated_webhook_mock,
     staff_api_client,
@@ -315,7 +315,7 @@ def test_attribute_value_bulk_translate_updates_translations_using_value_externa
     assert data["results"][1]["translation"]["name"] == "Rot"
     assert data["results"][1]["translation"]["plainText"] == expected_text
     assert data["results"][1]["translation"]["richText"] == expected_rich_text
-    assert updated_webhook_mock.call_count == 2
+    assert updated_webhook_mock.call_count == 1
 
 
 def test_attribute_value_bulk_translate_return_error_when_value_id_and_external_ref(

--- a/saleor/graphql/translations/tests/mutations/test_product_bulk_translate.py
+++ b/saleor/graphql/translations/tests/mutations/test_product_bulk_translate.py
@@ -35,7 +35,7 @@ description_pl = dummy_editorjs("description PL", True)
 description_de = dummy_editorjs("description DE", True)
 
 
-@patch("saleor.plugins.manager.PluginsManager.translation_created")
+@patch("saleor.plugins.manager.PluginsManager.translations_created")
 def test_product_bulk_translate_creates_translations(
     created_webhook_mock,
     staff_api_client,
@@ -79,10 +79,10 @@ def test_product_bulk_translate_creates_translations(
     assert data["results"][0]["translation"]["description"] == description_pl
     assert data["results"][1]["translation"]["name"] == "Product DE"
     assert data["results"][1]["translation"]["description"] == description_de
-    assert created_webhook_mock.call_count == 2
+    assert created_webhook_mock.call_count == 1
 
 
-@patch("saleor.plugins.manager.PluginsManager.translation_updated")
+@patch("saleor.plugins.manager.PluginsManager.translations_updated")
 def test_product_bulk_translate_updates_translations(
     updated_webhook_mock,
     staff_api_client,
@@ -130,10 +130,10 @@ def test_product_bulk_translate_updates_translations(
     assert data["count"] == 2
     assert data["results"][0]["translation"]["name"] == "NewProduct PL"
     assert data["results"][1]["translation"]["name"] == "NewProduct DE"
-    assert updated_webhook_mock.call_count == 2
+    assert updated_webhook_mock.call_count == 1
 
 
-@patch("saleor.plugins.manager.PluginsManager.translation_created")
+@patch("saleor.plugins.manager.PluginsManager.translations_created")
 def test_product_bulk_translate_creates_translations_using_attr_external_ref(
     created_webhook_mock,
     staff_api_client,
@@ -177,10 +177,10 @@ def test_product_bulk_translate_creates_translations_using_attr_external_ref(
     assert data["results"][0]["translation"]["description"] == description_pl
     assert data["results"][1]["translation"]["name"] == "Product DE"
     assert data["results"][1]["translation"]["description"] == description_de
-    assert created_webhook_mock.call_count == 2
+    assert created_webhook_mock.call_count == 1
 
 
-@patch("saleor.plugins.manager.PluginsManager.translation_updated")
+@patch("saleor.plugins.manager.PluginsManager.translations_updated")
 def test_product_bulk_translate_updates_translations_using_attr_external_ref(
     updated_webhook_mock,
     staff_api_client,
@@ -231,7 +231,7 @@ def test_product_bulk_translate_updates_translations_using_attr_external_ref(
     assert data["results"][0]["translation"]["description"] == description_pl
     assert data["results"][1]["translation"]["name"] == "NewProduct DE"
     assert data["results"][1]["translation"]["description"] == description_de
-    assert updated_webhook_mock.call_count == 2
+    assert updated_webhook_mock.call_count == 1
 
 
 def test_product_bulk_translate_return_error_when_attr_id_and_external_ref(

--- a/saleor/graphql/translations/tests/mutations/test_product_variant_bulk_translate.py
+++ b/saleor/graphql/translations/tests/mutations/test_product_variant_bulk_translate.py
@@ -30,7 +30,7 @@ PRODUCT_VARIANT_BULK_TRANSLATE_MUTATION = """
 """
 
 
-@patch("saleor.plugins.manager.PluginsManager.translation_created")
+@patch("saleor.plugins.manager.PluginsManager.translations_created")
 def test_product_variant_variant_bulk_translate_creates_translations(
     created_webhook_mock,
     staff_api_client,
@@ -72,10 +72,10 @@ def test_product_variant_variant_bulk_translate_creates_translations(
     assert data["count"] == 2
     assert data["results"][0]["translation"]["name"] == "Product PL"
     assert data["results"][1]["translation"]["name"] == "Product DE"
-    assert created_webhook_mock.call_count == 2
+    assert created_webhook_mock.call_count == 1
 
 
-@patch("saleor.plugins.manager.PluginsManager.translation_updated")
+@patch("saleor.plugins.manager.PluginsManager.translations_updated")
 def test_product_variant_bulk_translate_updates_translations(
     updated_webhook_mock,
     staff_api_client,
@@ -123,10 +123,10 @@ def test_product_variant_bulk_translate_updates_translations(
     assert data["count"] == 2
     assert data["results"][0]["translation"]["name"] == "NewVariant PL"
     assert data["results"][1]["translation"]["name"] == "NewVariant DE"
-    assert updated_webhook_mock.call_count == 2
+    assert updated_webhook_mock.call_count == 1
 
 
-@patch("saleor.plugins.manager.PluginsManager.translation_created")
+@patch("saleor.plugins.manager.PluginsManager.translations_created")
 def test_product_variant_bulk_translate_creates_translations_using_attr_external_ref(
     created_webhook_mock,
     staff_api_client,
@@ -172,10 +172,10 @@ def test_product_variant_bulk_translate_creates_translations_using_attr_external
     assert data["count"] == 2
     assert data["results"][0]["translation"]["name"] == "Variant PL"
     assert data["results"][1]["translation"]["name"] == "Variant DE"
-    assert created_webhook_mock.call_count == 2
+    assert created_webhook_mock.call_count == 1
 
 
-@patch("saleor.plugins.manager.PluginsManager.translation_updated")
+@patch("saleor.plugins.manager.PluginsManager.translations_updated")
 def test_product_variant_bulk_translate_updates_translations_using_attr_external_ref(
     updated_webhook_mock,
     staff_api_client,
@@ -222,7 +222,7 @@ def test_product_variant_bulk_translate_updates_translations_using_attr_external
     assert data["count"] == 2
     assert data["results"][0]["translation"]["name"] == "NewVariant PL"
     assert data["results"][1]["translation"]["name"] == "NewVariant DE"
-    assert updated_webhook_mock.call_count == 2
+    assert updated_webhook_mock.call_count == 1
 
 
 def test_product_variant_bulk_translate_return_error_when_attr_id_and_external_ref(

--- a/saleor/graphql/translations/tests/mutations/test_promotion_rule_translate.py
+++ b/saleor/graphql/translations/tests/mutations/test_promotion_rule_translate.py
@@ -2,10 +2,10 @@ import json
 from unittest.mock import ANY, patch
 
 import graphene
-from django.utils.functional import SimpleLazyObject
 from freezegun import freeze_time
 
 from .....webhook.event_types import WebhookEventAsyncType
+from .....webhook.transport.asynchronous.transport import WebhookPayloadData
 from ....tests.utils import assert_no_permission, get_graphql_content
 
 PROMOTION_RULE_TRANSLATE_MUTATION = """
@@ -40,9 +40,9 @@ PROMOTION_RULE_TRANSLATE_MUTATION = """
 
 @freeze_time("2023-06-01 10:00")
 @patch("saleor.plugins.webhook.plugin.get_webhooks_for_event")
-@patch("saleor.plugins.webhook.plugin.trigger_webhooks_async")
+@patch("saleor.plugins.webhook.plugin.trigger_webhooks_async_for_multiple_objects")
 def test_promotion_rule_create_translation(
-    mocked_webhook_trigger,
+    mocked_webhook_trigger_for_multiple_objects,
     mocked_get_webhooks_for_event,
     any_webhook,
     staff_api_client,
@@ -83,14 +83,15 @@ def test_promotion_rule_create_translation(
     assert translation_data["language"]["code"] == "PL"
 
     translation = promotion_rule.translations.first()
-    mocked_webhook_trigger.assert_called_once_with(
-        None,
+    mocked_webhook_trigger_for_multiple_objects.assert_called_once_with(
         WebhookEventAsyncType.TRANSLATION_CREATED,
         [any_webhook],
-        translation,
-        SimpleLazyObject(lambda: staff_api_client.user),
-        legacy_data_generator=ANY,
-        allow_replica=False,
+        webhook_payloads_data=[
+            WebhookPayloadData(
+                subscribable_object=translation, legacy_data_generator=ANY, data=None
+            )
+        ],
+        requestor=staff_api_client.user,
     )
 
 

--- a/saleor/graphql/translations/tests/mutations/test_promotion_translate.py
+++ b/saleor/graphql/translations/tests/mutations/test_promotion_translate.py
@@ -2,10 +2,10 @@ import json
 from unittest.mock import ANY, patch
 
 import graphene
-from django.utils.functional import SimpleLazyObject
 from freezegun import freeze_time
 
 from .....webhook.event_types import WebhookEventAsyncType
+from .....webhook.transport.asynchronous.transport import WebhookPayloadData
 from ....tests.utils import assert_no_permission, get_graphql_content
 
 PROMOTION_TRANSLATE_MUTATION = """
@@ -41,9 +41,9 @@ PROMOTION_TRANSLATE_MUTATION = """
 
 @freeze_time("2023-06-01 10:00")
 @patch("saleor.plugins.webhook.plugin.get_webhooks_for_event")
-@patch("saleor.plugins.webhook.plugin.trigger_webhooks_async")
+@patch("saleor.plugins.webhook.plugin.trigger_webhooks_async_for_multiple_objects")
 def test_promotion_create_translation(
-    mocked_webhook_trigger,
+    mocked_webhook_trigger_for_multiple_objects,
     mocked_get_webhooks_for_event,
     any_webhook,
     staff_api_client,
@@ -86,14 +86,15 @@ def test_promotion_create_translation(
     assert translation_data["__typename"] == "PromotionTranslation"
 
     translation = promotion.translations.first()
-    mocked_webhook_trigger.assert_called_once_with(
-        None,
+    mocked_webhook_trigger_for_multiple_objects.assert_called_once_with(
         WebhookEventAsyncType.TRANSLATION_CREATED,
         [any_webhook],
-        translation,
-        SimpleLazyObject(lambda: staff_api_client.user),
-        legacy_data_generator=ANY,
-        allow_replica=False,
+        webhook_payloads_data=[
+            WebhookPayloadData(
+                subscribable_object=translation, legacy_data_generator=ANY, data=None
+            )
+        ],
+        requestor=staff_api_client.user,
     )
 
 

--- a/saleor/graphql/translations/tests/mutations/test_sale_translate.py
+++ b/saleor/graphql/translations/tests/mutations/test_sale_translate.py
@@ -1,11 +1,11 @@
 from unittest.mock import ANY, patch
 
 import graphene
-from django.utils.functional import SimpleLazyObject
 from freezegun import freeze_time
 
 from .....discount.error_codes import DiscountErrorCode
 from .....webhook.event_types import WebhookEventAsyncType
+from .....webhook.transport.asynchronous.transport import WebhookPayloadData
 from ....tests.utils import get_graphql_content
 
 SALE_TRANSLATE_MUTATION = """
@@ -41,9 +41,9 @@ SALE_TRANSLATE_MUTATION = """
 
 @freeze_time("2023-06-01 10:00")
 @patch("saleor.plugins.webhook.plugin.get_webhooks_for_event")
-@patch("saleor.plugins.webhook.plugin.trigger_webhooks_async")
+@patch("saleor.plugins.webhook.plugin.trigger_webhooks_async_for_multiple_objects")
 def test_sale_translate(
-    mocked_webhook_trigger,
+    mocked_webhook_trigger_for_multiple_objects,
     mocked_get_webhooks_for_event,
     any_webhook,
     staff_api_client,
@@ -88,14 +88,15 @@ def test_sale_translate(
     assert type == "SaleTranslation"
 
     translation = promotion.translations.first()
-    mocked_webhook_trigger.assert_called_once_with(
-        None,
+    mocked_webhook_trigger_for_multiple_objects.assert_called_once_with(
         WebhookEventAsyncType.TRANSLATION_CREATED,
         [any_webhook],
-        translation,
-        SimpleLazyObject(lambda: staff_api_client.user),
-        legacy_data_generator=ANY,
-        allow_replica=False,
+        webhook_payloads_data=[
+            WebhookPayloadData(
+                subscribable_object=translation, legacy_data_generator=ANY, data=None
+            )
+        ],
+        requestor=staff_api_client.user,
     )
 
 

--- a/saleor/plugins/base_plugin.py
+++ b/saleor/plugins/base_plugin.py
@@ -42,6 +42,7 @@ if TYPE_CHECKING:
     from ..core.middleware import Requestor
     from ..core.notify import NotifyEventType
     from ..core.taxes import TaxData, TaxType
+    from ..core.utils.translations import Translation
     from ..csv.models import ExportFile
     from ..discount.models import Promotion, PromotionRule, Voucher, VoucherCode
     from ..giftcard.models import GiftCard
@@ -1228,6 +1229,24 @@ class BasePlugin:
     # Note: This method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
     # Webhook-related functionality will be moved from the plugin to core modules.
     transaction_item_metadata_updated: Callable[["TransactionItem", Any], Any]
+
+    # Trigger when transaction item metadata is updated.
+    #
+    # Overwrite this method if you need to trigger specific logic when a transaction
+    # item metadata is updated.
+    #
+    # Note: This method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Webhook-related functionality will be moved from the plugin to core modules.
+    translations_created: Callable[[list["Translation"], None, None], Any]
+
+    # Trigger when transaction item metadata is updated.
+    #
+    # Overwrite this method if you need to trigger specific logic when a transaction
+    # item metadata is updated.
+    #
+    # Note: This method is deprecated in Saleor 3.20 and will be removed in Saleor 3.21.
+    # Webhook-related functionality will be moved from the plugin to core modules.
+    translations_updated: Callable[[list["Translation"], None, None], Any]
 
     # Trigger when product is created.
     #

--- a/saleor/plugins/manager.py
+++ b/saleor/plugins/manager.py
@@ -2478,22 +2478,22 @@ class PluginsManager(PaymentInterface):
         )
         return response
 
-    def translation_created(self, translation: "Translation", webhooks=None):
+    def translations_created(self, translations: list["Translation"], webhooks=None):
         default_value = None
         return self.__run_method_on_plugins(
-            "translation_created",
+            "translations_created",
             default_value,
-            translation,
+            translations,
             channel_slug=None,
             webhooks=webhooks,
         )
 
-    def translation_updated(self, translation: "Translation", webhooks=None):
+    def translations_updated(self, translations: list["Translation"], webhooks=None):
         default_value = None
         return self.__run_method_on_plugins(
-            "translation_updated",
+            "translations_updated",
             default_value,
-            translation,
+            translations,
             channel_slug=None,
             webhooks=webhooks,
         )


### PR DESCRIPTION
Recreated from original PR: https://github.com/saleor/saleor/pull/17036

Improving number of queries and time execution of bulk translate mutations.

I've run the following tests against 2000 attributes translations.

Current main:
```
Queries: 9000 in 17.2680 (9000+ in fact, as this is limit set in django.db)

Memory during query execution:
resident size: 285MB
heap size: 228MB
```

After changes:
```
Queries: 149 in 0.6390

Memory during query execution:
resident size: 287MB
heap size: 228MB
```

I've also checked the same against smaller numb...